### PR TITLE
Travis Continuous Integration support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-language: c
+language: C
 
 before_install: sudo apt update
 
-install: sudo apt install build-essential devscripts debhelper dh-autoreconf libglib2.0-dev systemd
+install: sudo apt install build-essential devscripts debhelper dh-autoreconf libglib2.0-dev systemd fakeroot
 
 script: skip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+language: C
+
 before_install: sudo apt update
 
 install: sudo apt install build-essential devscripts debhelper dh-autoreconf libglib2.0-dev systemd
 
-script: dpkg-buildpackage -us -uc -b
+script: skip
+
+after_script: dpkg-buildpackage -us -uc -b

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: C
+language: c
 
 before_install: sudo apt update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+before_install: sudo apt update
+
+install: sudo apt install build-essential devscripts debhelper dh-autoreconf libglib2.0-dev systemd
+
+script: dpkg-buildpackage -us -uc -b

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # systemd-shim for MX Linux
+
+[![Build Status](https://travis-ci.com/Head-on-a-Stick/systemd-shim.svg?branch=Travis_CI)](https://travis-ci.com/Head-on-a-Stick/systemd-shim)
+
 This repo contains a fork of systemd-shim.  It builds a Debian Buster based debian package for MX Linux.
 It depends on a modified systemd (available here: https://github.com/knelsonmeister/systemd)
 


### PR DESCRIPTION
I've added support for [Travis CI](https://travis-ci.com/) with a build status widget in `README.md`.

The [application](https://github.com/marketplace/travis-ci) will have to be installed in the MX github repositories for it to work. Once the account is set up then the URL for the widget can be changed.

Here's my branch: https://travis-ci.com/Head-on-a-Stick/systemd-shim

Is this of any interest?